### PR TITLE
Fix code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -19,7 +19,7 @@ def index():
 
     elif author:
         cursor.execute(
-            "SELECT * FROM books WHERE author LIKE '%" + author + "%'"
+            "SELECT * FROM books WHERE author LIKE %s", ('%' + author + '%',)
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
Fixes [https://github.com/ahshaaban/skills-introduction-to-codeql/security/code-scanning/2](https://github.com/ahshaaban/skills-introduction-to-codeql/security/code-scanning/2)

To fix the problem, we need to use parameterized queries to safely embed the user-provided `author` value into the SQL query. This will ensure that the database connector library properly escapes the input, preventing SQL injection attacks.

- Replace the direct concatenation of the `author` value into the SQL query with a parameterized query.
- Modify the `cursor.execute` call to use a placeholder for the `author` value and pass the value as a parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
